### PR TITLE
Fixed Typos in Meta Tags

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,11 +9,11 @@ export default function Home() {
         <Head>
             {/* SEARCH ENGINE RELATIVE META */}
             <title>Orca Squad</title>
-            <meta name="description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major Leagu Hacking (MLH)"/>
+            <meta name="description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major League Hacking (MLH)"/>
             
             {/* OPEN GRAPH META */}
             <meta property="og:title" content="Orca Squad"/>
-            <meta property="og:description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major Leagu Hacking (MLH)"/>
+            <meta property="og:description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major League Hacking (MLH)"/>
             <meta property="og:image" content=" "/>
             <meta property="og:url" content="https://orcasquad.win"/>
             <meta property="og:site_name" content="Orca Squad"/>
@@ -23,7 +23,7 @@ export default function Home() {
             <meta name="twitter:card" content="summary"/>
             <meta name="twitter:site" content="@immattdavison"/>
             <meta name="twitter:title" content="Orca Squad"/>
-            <meta name="twitter:description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major Leagu Hacking (MLH)"/>
+            <meta name="twitter:description" content="Join Orca Squad, one of the leading Global Hack Week Guilds with Major League Hacking (MLH)"/>
             <meta name="twitter:image" content=" "/>
 
             {/* FAVICON */}


### PR DESCRIPTION
### Why This PR Adds Value

Fixed typos in meta tags so MLH is spelt correctly when the website is sharing on social media.

### What This PR Adds

- Fixes typos - Added the letter e to the end of leagu to correctly spell league in MLH when defined in the website's meta tags.